### PR TITLE
Add patch version support

### DIFF
--- a/config.go
+++ b/config.go
@@ -114,7 +114,7 @@ func defaultConfig() Config {
 func (c Config) check() error {
 	validName := regexp.MustCompile(`^([A-Za-z0-9_]|[\-])+$`)
 	validUTI := regexp.MustCompile(`^([A-Za-z0-9]|[\-]|[\.])+$`)
-	validMinVersion := regexp.MustCompile(`^[0-9]+[\.][0-9]+$`)
+	validMinVersion := regexp.MustCompile(`^[0-9]+([\.][0-9]+){1,2}$`)
 
 	if !validName.MatchString(c.Name) {
 		return fmt.Errorf("name from config must contain alphanumeric characters, '_' or '-' : %v", c.Name)

--- a/config.go
+++ b/config.go
@@ -125,11 +125,11 @@ func (c Config) check() error {
 	}
 
 	if !validMinVersion.MatchString(c.Version) {
-		return fmt.Errorf("version from config must follow the pattern x.x.x where x is a non negative number: %v", c.Version)
+		return fmt.Errorf("version from config must follow the pattern x.x or x.x.x where x is a non negative number: %v", c.Version)
 	}
 
 	if !validMinVersion.MatchString(c.DeploymentTarget) {
-		return fmt.Errorf("deployment-target from config must follow the pattern x.x.x where x is a non negative number: %v", c.DeploymentTarget)
+		return fmt.Errorf("deployment-target from config must follow the pattern x.x x.x.x where x is a non negative number: %v", c.DeploymentTarget)
 	}
 
 	macOSDeploymentTarget := strings.Split(c.DeploymentTarget, ".")

--- a/config.go
+++ b/config.go
@@ -129,7 +129,7 @@ func (c Config) check() error {
 	}
 
 	if !validMinVersion.MatchString(c.DeploymentTarget) {
-		return fmt.Errorf("deployment-target from config must follow the pattern x.x x.x.x where x is a non negative number: %v", c.DeploymentTarget)
+		return fmt.Errorf("deployment-target from config must follow the pattern x.x or x.x.x where x is a non negative number: %v", c.DeploymentTarget)
 	}
 
 	macOSDeploymentTarget := strings.Split(c.DeploymentTarget, ".")

--- a/config.go
+++ b/config.go
@@ -125,11 +125,11 @@ func (c Config) check() error {
 	}
 
 	if !validMinVersion.MatchString(c.Version) {
-		return fmt.Errorf("version from config must follow the pattern x.x where x is a non negative number: %v", c.Version)
+		return fmt.Errorf("version from config must follow the pattern x.x.x where x is a non negative number: %v", c.Version)
 	}
 
 	if !validMinVersion.MatchString(c.DeploymentTarget) {
-		return fmt.Errorf("deployment-target from config must follow the pattern x.x where x is a non negative number: %v", c.DeploymentTarget)
+		return fmt.Errorf("deployment-target from config must follow the pattern x.x.x where x is a non negative number: %v", c.DeploymentTarget)
 	}
 
 	macOSDeploymentTarget := strings.Split(c.DeploymentTarget, ".")


### PR DESCRIPTION
Macpack doesn't forbid you to set a version for `0.0.0`, but it will complain. There are a number of mac applications that include a patch version, including the first one I checked:

<img width="396" alt="screen shot 2017-02-21 at 11 55 34 pm" src="https://cloud.githubusercontent.com/assets/1558388/23190677/4647c7e2-f891-11e6-9cf8-d30d227ea644.png">